### PR TITLE
upgrade PMD from 6.13.0 to 6.22.0, for support JDK 13, 14.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
   </developers>
 
   <properties>
-    <pmd.version>6.13.0</pmd.version>
+    <pmd.version>6.22.0</pmd.version>
     <junit.jupiter.version>5.6.0</junit.jupiter.version>
     <mockito.version>3.2.4</mockito.version>
     <assertj.version>3.14.0</assertj.version>

--- a/sonar-pmd-plugin/pom.xml
+++ b/sonar-pmd-plugin/pom.xml
@@ -135,7 +135,7 @@
             <configuration>
               <rules>
                 <requireFilesSize>
-                  <maxsize>7000000</maxsize>
+                  <maxsize>7200000</maxsize>
                   <minsize>4200000</minsize>
                   <files>
                     <file>${project.build.directory}/${project.build.finalName}.jar</file>

--- a/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/PmdTemplate.java
+++ b/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/PmdTemplate.java
@@ -22,6 +22,7 @@ package org.sonar.plugins.pmd;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -95,7 +96,7 @@ public class PmdTemplate {
     }
 
     public void process(InputFile file, RuleSets rulesets, RuleContext ruleContext) {
-        ruleContext.setSourceCodeFilename(file.uri().toString());
+        ruleContext.setSourceCodeFile(Paths.get(file.uri()).toFile());
 
         try (InputStream inputStream = file.inputStream()) {
             processor.processSourceCode(inputStream, rulesets, ruleContext);

--- a/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/PmdViolationRecorder.java
+++ b/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/PmdViolationRecorder.java
@@ -20,6 +20,7 @@
 package org.sonar.plugins.pmd;
 
 import java.net.URI;
+import java.nio.file.Paths;
 
 import net.sourceforge.pmd.RuleViolation;
 import org.sonar.api.batch.ScannerSide;
@@ -72,7 +73,7 @@ public class PmdViolationRecorder {
     }
 
     private InputFile findResourceFor(RuleViolation violation) {
-        final URI uri = URI.create(violation.getFilename());
+        final URI uri = Paths.get(violation.getFilename()).toUri();
         return fs.inputFile(
                 fs.predicates().hasURI(uri)
         );

--- a/sonar-pmd-plugin/src/test/java/org/sonar/plugins/pmd/PmdTemplateTest.java
+++ b/sonar-pmd-plugin/src/test/java/org/sonar/plugins/pmd/PmdTemplateTest.java
@@ -23,6 +23,7 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -71,7 +72,7 @@ class PmdTemplateTest {
 
         new PmdTemplate(configuration, processor).process(inputFile, rulesets, ruleContext);
 
-        verify(ruleContext).setSourceCodeFilename(inputFile.uri().toString());
+        verify(ruleContext).setSourceCodeFile(Paths.get(inputFile.uri()).toFile());
         verify(processor).processSourceCode(any(InputStream.class), eq(rulesets), eq(ruleContext));
     }
 

--- a/sonar-pmd-plugin/src/test/java/org/sonar/plugins/pmd/PmdViolationRecorderTest.java
+++ b/sonar-pmd-plugin/src/test/java/org/sonar/plugins/pmd/PmdViolationRecorderTest.java
@@ -137,7 +137,7 @@ class PmdViolationRecorderTest {
         final RuleViolation pmdViolation = mock(RuleViolation.class);
 
         when(rule.getName()).thenReturn(ruleName);
-        when(pmdViolation.getFilename()).thenReturn(file.toURI().toString());
+        when(pmdViolation.getFilename()).thenReturn(file.getPath());
         when(pmdViolation.getBeginLine()).thenReturn(2);
         when(pmdViolation.getDescription()).thenReturn("Description");
         when(pmdViolation.getRule()).thenReturn(rule);


### PR DESCRIPTION
#163 upgrade PMD from 6.13.0 to 6.22.0, for support JDK 13, 14.

fix throw IllegalArgumentException: "Missing scheme",
because of RuleContext.setSourceCodeFilename is do nothing,
so use RuleContext.setSourceCodeFile replace it.