### PR TITLE
Use correct parent classloader to fix Java 9 style modules.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
   </developers>
 
   <properties>
-    <pmd.version>6.13.0</pmd.version>
+    <pmd.version>6.22.0</pmd.version>
     <junit.jupiter.version>5.6.0</junit.jupiter.version>
     <mockito.version>3.2.4</mockito.version>
     <assertj.version>3.14.0</assertj.version>

--- a/sonar-pmd-plugin/pom.xml
+++ b/sonar-pmd-plugin/pom.xml
@@ -135,7 +135,7 @@
             <configuration>
               <rules>
                 <requireFilesSize>
-                  <maxsize>7000000</maxsize>
+                  <maxsize>7200000</maxsize>
                   <minsize>4200000</minsize>
                   <files>
                     <file>${project.build.directory}/${project.build.finalName}.jar</file>

--- a/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/PmdExecutor.java
+++ b/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/PmdExecutor.java
@@ -174,7 +174,7 @@ public class PmdExecutor {
                 throw new IllegalStateException("Failed to create the project classloader. Classpath element is invalid: " + file, e);
             }
         }
-        return new URLClassLoader(urls.toArray(new URL[0]), null);
+        return new URLClassLoader(urls.toArray(new URL[0]));
     }
 
     private String getSourceVersion() {

--- a/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/PmdExecutor.java
+++ b/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/PmdExecutor.java
@@ -36,6 +36,8 @@ import net.sourceforge.pmd.RuleSet;
 import net.sourceforge.pmd.RuleSetFactory;
 import net.sourceforge.pmd.RuleSetNotFoundException;
 import net.sourceforge.pmd.RuleSets;
+import net.sourceforge.pmd.RulesetsFactoryUtils;
+
 import org.sonar.api.batch.ScannerSide;
 import org.sonar.api.batch.fs.FilePredicates;
 import org.sonar.api.batch.fs.FileSystem;
@@ -138,7 +140,7 @@ public class PmdExecutor {
         String rulesXml = dumpXml(rulesProfile, repositoryKey);
         File ruleSetFile = pmdConfiguration.dumpXmlRuleSet(repositoryKey, rulesXml);
         String ruleSetFilePath = ruleSetFile.getAbsolutePath();
-        RuleSetFactory ruleSetFactory = new RuleSetFactory();
+        RuleSetFactory ruleSetFactory = RulesetsFactoryUtils.defaultFactory();
         try {
             RuleSet ruleSet = ruleSetFactory.createRuleSet(ruleSetFilePath);
             return new RuleSets(ruleSet);

--- a/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/PmdTemplate.java
+++ b/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/PmdTemplate.java
@@ -22,6 +22,7 @@ package org.sonar.plugins.pmd;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -95,7 +96,7 @@ public class PmdTemplate {
     }
 
     public void process(InputFile file, RuleSets rulesets, RuleContext ruleContext) {
-        ruleContext.setSourceCodeFilename(file.uri().toString());
+        ruleContext.setSourceCodeFile(Paths.get(file.uri()).toFile());
 
         try (InputStream inputStream = file.inputStream()) {
             processor.processSourceCode(inputStream, rulesets, ruleContext);

--- a/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/PmdViolationRecorder.java
+++ b/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/PmdViolationRecorder.java
@@ -20,6 +20,7 @@
 package org.sonar.plugins.pmd;
 
 import java.net.URI;
+import java.nio.file.Paths;
 
 import net.sourceforge.pmd.RuleViolation;
 import org.sonar.api.batch.ScannerSide;
@@ -72,7 +73,7 @@ public class PmdViolationRecorder {
     }
 
     private InputFile findResourceFor(RuleViolation violation) {
-        final URI uri = URI.create(violation.getFilename());
+        final URI uri = Paths.get(violation.getFilename()).toUri();
         return fs.inputFile(
                 fs.predicates().hasURI(uri)
         );

--- a/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/rule/ExternalDescriptionLoader.java
+++ b/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/rule/ExternalDescriptionLoader.java
@@ -23,7 +23,6 @@ package org.sonar.plugins.pmd.rule;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.PrintWriter;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 

--- a/sonar-pmd-plugin/src/test/java/org/sonar/plugins/pmd/PmdLevelUtilsTest.java
+++ b/sonar-pmd-plugin/src/test/java/org/sonar/plugins/pmd/PmdLevelUtilsTest.java
@@ -53,7 +53,7 @@ class PmdLevelUtilsTest {
 
     @Test
     void private_constructor() throws Exception {
-        Constructor constructor = PmdLevelUtils.class.getDeclaredConstructor();
+        Constructor<PmdLevelUtils> constructor = PmdLevelUtils.class.getDeclaredConstructor();
         assertThat(constructor.isAccessible()).isFalse();
         constructor.setAccessible(true);
         constructor.newInstance();

--- a/sonar-pmd-plugin/src/test/java/org/sonar/plugins/pmd/PmdTemplateTest.java
+++ b/sonar-pmd-plugin/src/test/java/org/sonar/plugins/pmd/PmdTemplateTest.java
@@ -23,6 +23,7 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -71,7 +72,7 @@ class PmdTemplateTest {
 
         new PmdTemplate(configuration, processor).process(inputFile, rulesets, ruleContext);
 
-        verify(ruleContext).setSourceCodeFilename(inputFile.uri().toString());
+        verify(ruleContext).setSourceCodeFile(Paths.get(inputFile.uri()).toFile());
         verify(processor).processSourceCode(any(InputStream.class), eq(rulesets), eq(ruleContext));
     }
 

--- a/sonar-pmd-plugin/src/test/java/org/sonar/plugins/pmd/PmdViolationRecorderTest.java
+++ b/sonar-pmd-plugin/src/test/java/org/sonar/plugins/pmd/PmdViolationRecorderTest.java
@@ -137,7 +137,7 @@ class PmdViolationRecorderTest {
         final RuleViolation pmdViolation = mock(RuleViolation.class);
 
         when(rule.getName()).thenReturn(ruleName);
-        when(pmdViolation.getFilename()).thenReturn(file.toURI().toString());
+        when(pmdViolation.getFilename()).thenReturn(file.getPath());
         when(pmdViolation.getBeginLine()).thenReturn(2);
         when(pmdViolation.getDescription()).thenReturn("Description");
         when(pmdViolation.getRule()).thenReturn(rule);


### PR DESCRIPTION
Use correct parent classloader to fix Java 9 style modules.

This fixes the issue at https://github.com/jensgerdes/sonar-pmd/issues/87. It also includes fixes for https://github.com/jensgerdes/sonar-pmd/issues/117. 