### PR TITLE
patch for pmd 6.25.0 violation filename

### DIFF
--- a/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/PmdViolationRecorder.java
+++ b/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/PmdViolationRecorder.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.plugins.pmd;
 
+import java.io.File;
 import java.net.URI;
 
 import net.sourceforge.pmd.RuleViolation;
@@ -72,7 +73,12 @@ public class PmdViolationRecorder {
     }
 
     private InputFile findResourceFor(RuleViolation violation) {
-        final URI uri = URI.create(violation.getFilename());
+        final URI uri;
+        if (violation.getFilename().startsWith("file:/")) {
+            uri = URI.create(violation.getFilename());
+        } else {
+            uri = new File(violation.getFilename()).toURI();
+        }
         return fs.inputFile(
                 fs.predicates().hasURI(uri)
         );


### PR DESCRIPTION
When I upgrade pmd to 6.25.0, pmd set RuleViolation filename not with 'file:' scheme.
Therefor, sonar-pmd `findResourceFor` function would throw "Missing scheme" Exception.

I made  a patch for that, show as code.
