### PR TITLE
Correlate PMD RuleViolations with Sonar Files using Paths

### DIFF
--- a/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/PmdViolationRecorder.java
+++ b/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/PmdViolationRecorder.java
@@ -30,8 +30,6 @@ import org.sonar.api.batch.sensor.issue.NewIssue;
 import org.sonar.api.batch.sensor.issue.NewIssueLocation;
 import org.sonar.api.rule.RuleKey;
 
-import java.net.URI;
-
 @ScannerSide
 public class PmdViolationRecorder {
 
@@ -72,9 +70,10 @@ public class PmdViolationRecorder {
     }
 
     private InputFile findResourceFor(RuleViolation violation) {
-        final URI uri = URI.create(violation.getFilename());
         return fs.inputFile(
-                fs.predicates().hasURI(uri)
+                fs.predicates().hasAbsolutePath(
+                        violation.getFilename()
+                )
         );
     }
 

--- a/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/ProjectDataSource.java
+++ b/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/ProjectDataSource.java
@@ -24,6 +24,7 @@ import org.sonar.api.batch.fs.InputFile;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Paths;
 
 public class ProjectDataSource implements DataSource {
 
@@ -40,7 +41,9 @@ public class ProjectDataSource implements DataSource {
 
     @Override
     public String getNiceFileName(boolean shortNames, String inputFileName) {
-        return inputFile.uri().toString();
+        return Paths.get(inputFile.uri())
+                .toAbsolutePath()
+                .toString();
     }
 
     @Override

--- a/sonar-pmd-plugin/src/test/java/org/sonar/plugins/pmd/PmdViolationRecorderTest.java
+++ b/sonar-pmd-plugin/src/test/java/org/sonar/plugins/pmd/PmdViolationRecorderTest.java
@@ -19,11 +19,8 @@
  */
 package org.sonar.plugins.pmd;
 
-import java.io.File;
-
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleViolation;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.batch.fs.FilePredicate;
 import org.sonar.api.batch.fs.TextRange;
@@ -36,6 +33,8 @@ import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.issue.NewIssue;
 import org.sonar.api.batch.sensor.issue.NewIssueLocation;
 import org.sonar.api.rule.RuleKey;
+
+import java.io.File;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -138,7 +137,7 @@ class PmdViolationRecorderTest {
         final RuleViolation pmdViolation = mock(RuleViolation.class);
 
         when(rule.getName()).thenReturn(ruleName);
-        when(pmdViolation.getFilename()).thenReturn(file.toURI().toString());
+        when(pmdViolation.getFilename()).thenReturn(file.getAbsolutePath());
         when(pmdViolation.getBeginLine()).thenReturn(2);
         when(pmdViolation.getDescription()).thenReturn("Description");
         when(pmdViolation.getRule()).thenReturn(rule);


### PR DESCRIPTION
Use Paths instead of File URIs to correlate PMD RuleViolations with Sonar Files because Windows File Paths can not be correctly represented as URI